### PR TITLE
fix getDirectories prefix parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,7 +315,7 @@ function getDirectories(srcpath, acceptedPrefix) {
             //console.log(file);
             try{
                 var joinedPath = pathTemp.join(srcpath, file);
-                if ((acceptedPrefix==null || file.substring(0,3)==acceptedPrefix) && joinedPath !== null) {
+                if ((acceptedPrefix==null || file.substring(0,acceptedPrefix.length)==acceptedPrefix) && joinedPath !== null) {
                     // only accept folders (potential addons)
                     return fsTemp.statSync(joinedPath).isDirectory();
                 }


### PR DESCRIPTION
was always checking prefixes of length 3 which works for 'ofx' when parsing the addons but would fail if someone tries to use the function with some other prefix
